### PR TITLE
Add proper check for empty content before displaying UI

### DIFF
--- a/lua/hovercraft/test/ui_spec.lua
+++ b/lua/hovercraft/test/ui_spec.lua
@@ -1,6 +1,8 @@
 local UI = require('hovercraft.ui')
 
 local eq = assert.are.same
+local is_true = assert.is.True
+local is_false = assert.is.False
 
 ---@param num integer number of dummy providers to create
 ---@return string[]
@@ -105,6 +107,26 @@ describe('hovercraft', function()
       local next_provider_id = UI._get_next_provider_id(providers, current_provider_id, -4, false)
 
       eq(providers[1], next_provider_id)
+    end)
+  end)
+
+  describe('hovercraft._is_empty_content', function()
+    it('should return true for empty content table', function()
+      local result = UI._is_empty_content({})
+
+      is_true(result)
+    end)
+
+    it('should return true for content table with only empty strings', function()
+      local result = UI._is_empty_content({'', ''})
+
+      is_true(result)
+    end)
+
+    it('should return false for content table with non empty lines', function()
+      local result = UI._is_empty_content({'', 'hello'})
+
+      is_false(result)
     end)
   end)
 end)

--- a/lua/hovercraft/ui.lua
+++ b/lua/hovercraft/ui.lua
@@ -159,6 +159,21 @@ function UI:_close_preview_autocmd(events, winnr, bufnrs)
   end
 end
 
+---@param content string[]
+function M._is_empty_content(content)
+  if vim.tbl_isempty(content) then
+    return true
+  end
+
+  for _, line in ipairs(content) do
+    if line:len() > 0 then
+      return false
+    end
+  end
+
+  return true
+end
+
 ---@param bufnr number
 ---@return string[]
 function UI:_get_active_provider_ids(bufnr, pos)
@@ -234,7 +249,7 @@ function UI:show(opts)
       contents = vim.lsp.util.convert_input_to_markdown_lines(result.lines or {})
     end
 
-    if vim.tbl_isempty(contents) then
+    if M._is_empty_content(contents) then
       contents = { '-- No information available --' }
     end
 


### PR DESCRIPTION
There are cases, when providers will return an content table with an empty string for display. This caused it to fall through the is empty check, causing hovercraft to crash, as the opened popup would have a width of `0`.

To fix this, there is now a more elaborate `_is_empty_content` check, as well as some tests to ensure it is working as expected.

Fixes #3